### PR TITLE
fix missing or undefined data by checking for data as well as message

### DIFF
--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -55,7 +55,7 @@ class EventSource extends EventSourceBase {
           return;
         }
         var event = new EventSourceEvent(ev.type, {
-          data: ev.message
+          data: ev.message || ev.data
         });
         if( ev.type === 'message' && this.onmessage ) this.onmessage(event);
         this.dispatchEvent(event);


### PR DESCRIPTION
this could probably just be `data: ev.data` but leaving it as `data: ev.message || ev.data` should be non breaking

fixes #9 